### PR TITLE
Fehlermeldung "Allowed memory size ..." in Zeile 151 behoben

### DIFF
--- a/Phpmodbus/ModbusMaster.php
+++ b/Phpmodbus/ModbusMaster.php
@@ -147,8 +147,9 @@ class ModbusMaster {
             $writesocks, 
             $exceptsocks,
             0, 
-            300000) !== FALSE) {
-            $this->status .= "Wait data ... \n";
+            $this->timeout_sec) !== FALSE)                      // ursprünglich 300000us = 300s = 5min ?! blockiert socket_select falls keine Daten kommen. Das ist für eine Abfrage sehr lange!
+    {                                   
+        $this->status .= "Wait data ... \n";                    // Fehlermeldung alle ~2h 20min: "Datei: /usr/local/edomi/main/include/php/ModbusMaster.php | Fehlercode: 1 | Zeile: 151 | Allowed memory size of 67108864 bytes exhausted (tried to allocate 4392558 bytes)" Vermutlich weil die Verbindung unterbrochen war und die while immer wieder lief.
         if (in_array($this->sock, $readsocks)) {
             while (@socket_recv($this->sock, $rec, 2000, 0)) {
                 $this->status .= "Data received\n";
@@ -160,6 +161,7 @@ class ModbusMaster {
                 throw new Exception( "Watchdog time expired [ " .
                   $this->timeout_sec . " sec]!!! Connection to " . 
                   $this->host . " is not established.");
+                  return $rec;                                    // return bei Timeout hinzugefügt, ansonsten startet die ursprüngliche while von foren
             }
         }
         $readsocks[] = $this->sock;


### PR DESCRIPTION
In der Funktion rec() wird blockierend auf daten gewartet. Ein Wartezyklus war dabei auf 5 min. => Reduzirt auf das globale Timeout. Insofern das Timout abgelaufen ist, wurde zwar eine Exception geworfen, die schleife wurde aber nicht beendet! => Das Erklärt die Fehlemeldung.